### PR TITLE
Build the JAR packages using docker.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Just so that we don't store the docker image build output into the repository.
+mvn-output/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+#
+# Build stage
+#
+FROM maven:3.6.0-jdk-11-slim
+
+WORKDIR /
+
+# Copy dependencies for the build
+COPY src /home/app/src
+COPY pom.xml /home/app
+
+# Download dependencies and package the app
+RUN mvn -f /home/app/pom.xml clean package
+
+# Generate destination folder
+RUN mkdir /output
+RUN chmod +w /output
+
+# We sleep for a few seconds, just enough time for the `make package-image` command
+# to successfully to copy out the files from the running container.
+CMD sleep 5

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+
+IMAGE=jessylenne/keycloak-event-listener-http
+VERSION=latest
+CONTAINER_NAME=keycloak-listener-war-builder
+JAR_ONE=event-listener-http-jar-with-dependencies.jar
+JAR_TWO=event-listener-http.jar
+
+package-image:
+# Build the docker image that we'll use to constrct the maven package
+	docker build . -t "${IMAGE}:${VERSION}"
+# Build the maven package, then save the resulting files into `mvn-output`
+	docker run -d --rm --name ${CONTAINER_NAME} -v ${PWD}/mvn-output:/output ${IMAGE}:${VERSION}
+# Ensure that you have proper write permissions to write on the `mvn-output` folder.
+# See: https://stackoverflow.com/a/45276559/1323398
+	docker cp ${CONTAINER_NAME}:/home/app/target/event-listener-http-jar-with-dependencies.jar ${PWD}/mvn-output/event-listener-http-jar-with-dependencies.jar
+	docker cp ${CONTAINER_NAME}:/home/app/target/event-listener-http.jar ${PWD}/mvn-output/event-listener-http.jar

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ package-image:
 	docker build . -t "${IMAGE}:${VERSION}"
 # Build the maven package, then save the resulting files into `mvn-output`
 	docker run -d --rm --name ${CONTAINER_NAME} -v ${PWD}/mvn-output:/output ${IMAGE}:${VERSION}
+	mkdir -p mvn-output
 # Ensure that you have proper write permissions to write on the `mvn-output` folder.
 # See: https://stackoverflow.com/a/45276559/1323398
 	docker cp ${CONTAINER_NAME}:/home/app/target/event-listener-http-jar-with-dependencies.jar ${PWD}/mvn-output/event-listener-http-jar-with-dependencies.jar

--- a/README.md
+++ b/README.md
@@ -1,12 +1,33 @@
 # keycloak-event-listener-http
 
 A Keycloak SPI that publishes events to an HTTP Webhook.
-A (largely) adaptation of @mhui mhuin/keycloak-event-listener-mqtt SPI
+A (largely) adaptation of @mhui mhuin/keycloak-event-listener-mqtt SPI.
+Extended by @darrensapalo to [enable building the JAR files from docker images](https://sapalo.dev/2021/06/16/send-keycloak-webhook-events/).
 
 # Build
 
+## Build on your local machine
+
 ```
 mvn clean install
+```
+
+## Build using docker
+
+Alternatively, you can [build the JAR files from a docker image](https://sapalo.dev/2021/06/16/send-keycloak-webhook-events/). You must have `docker` installed.
+
+1. Run `make package-image`.
+2. The JAR files should show up on your `mvn-output` folder.
+
+If you encounter the following issue: 
+```
+open {PATH}/mvn-output/event-listener-http-jar-with-dependencies.jar: permission denied
+```
+
+Simply add write permissions to the `mvn-output` folder:
+
+```
+sudo chown $USER:$USER mvn-output
 ```
 
 # Deploy


### PR DESCRIPTION
Fairly straight forward.

Added a way to build the keycloak plugin with just the following line:

```bash
make package-image
```