### PR TITLE
Fix poorly formed Event string representation

### DIFF
--- a/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventListenerProvider.java
+++ b/src/main/java/org/softwarefactory/keycloak/providers/events/http/HTTPEventListenerProvider.java
@@ -166,8 +166,8 @@ public class HTTPEventListenerProvider implements EventListenerProvider {
                 sb.append(e.getValue());
                 sb.append("', ");
             }
-        sb.append("}}");
         }
+        sb.append("}}");
 
         return sb.toString();
     }


### PR DESCRIPTION
Closing details braces in Event toString operation only render correctly if the Event has details.